### PR TITLE
Typeless field support

### DIFF
--- a/src/Classes.jl
+++ b/src/Classes.jl
@@ -253,11 +253,11 @@ function _defclass(clsname, supercls, mutable, wheres, exprs)
     ctors  = Vector{Expr}()
     fields = Vector{Union{Expr, Symbol}}()
     for ex in exprs
-        try
+        if ex isa Symbol || (ex isa Expr && ex.head === :(::) && ex.args[1] isa Symbol )  # x or x::Int64
+            push!(fields, ex)
+        else
             splitdef(ex)        # throws AssertionError if not a func def
             push!(ctors, ex)
-        catch
-            push!(fields, ex)
         end
     end
 

--- a/src/Classes.jl
+++ b/src/Classes.jl
@@ -251,7 +251,7 @@ function _defclass(clsname, supercls, mutable, wheres, exprs)
 
     # partition expressions into constructors and field defs
     ctors  = Vector{Expr}()
-    fields = Vector{Expr}()
+    fields = Vector{Union{Expr, Symbol}}()
     for ex in exprs
         try
             splitdef(ex)        # throws AssertionError if not a func def

--- a/test/test_classes.jl
+++ b/test/test_classes.jl
@@ -158,3 +158,11 @@ obj = AbstractLog{Float64}([1. 2.; 3. 4.])
 #     #= /Users/rjp/.julia/packages/MacroTools/4AjBS/src/utils.jl:302 =#
 #     new{T3, T4}(one, two, x, y)
 # end
+
+# x is a typeless field
+@class Cat begin
+    x
+end
+
+@test Cat(1).x == 1
+@test Cat("a").x == "a"


### PR DESCRIPTION
Adds support for typeless field

```julia
# x is a typeless field
@class Cat begin
    x
end
```

Also, makes the script detect the fields instead of using `try-catch`.